### PR TITLE
Created dashboard skeleton with NavBar and AppBar

### DIFF
--- a/client/src/NavBar/NavBar.tsx
+++ b/client/src/NavBar/NavBar.tsx
@@ -1,0 +1,76 @@
+import { Container, Grid, AppBar, Toolbar, Typography, IconButton, Button } from '@material-ui/core/';
+import { CalendarTodayOutlined, DashboardOutlined } from '@material-ui/icons';
+import AddIcon from '@material-ui/icons/Add';
+import MenuIcon from '@material-ui/icons/Menu';
+import AccountButton from '../AccountButton/AccountButton';
+import useStyles from './useStyles';
+import logo from '../../Images/logo.png';
+
+export default function NavBar() {
+  const classes = useStyles();
+
+  return (
+    <Container className={classes.root}>
+      <Grid container direction="row" alignItems="center" justify="center" className={classes.topnavBar}>
+        <Grid item xs={3}>
+          <Grid
+            container
+            spacing={1}
+            direction="row"
+            alignItems="center"
+            justify="flex-start"
+            className={classes.kanLogo}
+          >
+            <img src={logo} alt="logo" />
+          </Grid>
+        </Grid>
+        <Grid item xs>
+          <Grid container alignItems="center" justify="flex-end">
+            <Grid item>
+              <Button size="large" startIcon={<DashboardOutlined />} className={classes.buttonFonts}>
+                Dashboard
+              </Button>
+            </Grid>
+            <Grid item className={classes.calendarButton}>
+              <Button size="large" startIcon={<CalendarTodayOutlined />} className={classes.buttonFonts}>
+                Calendar
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item xs>
+          <Grid container alignItems="center" justify="flex-end">
+            <Grid>
+              <Button
+                variant="contained"
+                color="primary"
+                size="large"
+                className={classes.createboardButton}
+                startIcon={<AddIcon />}
+              >
+                Create board
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item xs={1}>
+          <Grid container alignItems="center" justify="flex-end" className={classes.accountButton}>
+            <Grid>
+              <AccountButton />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+      <AppBar position="static" className={classes.appbarStyle}>
+        <Toolbar>
+          <Typography variant="h6" className={classes.title}>
+            My School Board
+          </Typography>
+          <IconButton edge="end" className={classes.menuButton} color="inherit" aria-label="menu">
+            <MenuIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+    </Container>
+  );
+}

--- a/client/src/NavBar/useStyles.ts
+++ b/client/src/NavBar/useStyles.ts
@@ -1,0 +1,54 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      maxWidth: '100%',
+      padding: '0px',
+      overflow: 'hidden',
+    },
+    topnavBar: {
+      maxWidth: '100%',
+      padding: '10px 0px 10px 0px',
+      minHeight: 90,
+    },
+    kanLogo: {
+      padding: '1px 1px 1px 50px',
+    },
+    calendarButton: {
+      padding: '0px 0px 0px 50px',
+    },
+    buttonFonts: {
+      fontSize: '1.3em',
+    },
+    accountButton: {
+      padding: '0px 10px 0px 0px',
+    },
+    createboardButton: {
+      margin: theme.spacing(1),
+      width: '180px',
+      height: '45px',
+      background: 'rgba(117,156,252,255)',
+      boxShadow: 'none',
+      fontWeight: 600,
+      fontSize: '1.2em',
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+    },
+    title: {
+      padding: '1px 1px 1px 30px',
+      flexGrow: 1,
+      fontWeight: 600,
+    },
+    appbarStyle: {
+      background: 'rgba(117,156,252,255)',
+      boxShadow: 'none',
+      margin: '0px',
+      padding: '0px',
+    },
+  }),
+);
+
+export default useStyles;

--- a/client/src/components/AccountButton/AccountButton.tsx
+++ b/client/src/components/AccountButton/AccountButton.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Container, IconButton } from '@material-ui/core/';
+import useStyles from './useStyles';
+import MenuItem from '@material-ui/core/MenuItem';
+import Menu from '@material-ui/core/Menu';
+import { useAuth } from '../../context/useAuthContext';
+import { AccountCircle } from '@material-ui/icons';
+
+export default function AccountButton() {
+  const classes = useStyles();
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const { logout } = useAuth();
+
+  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleLogout = () => {
+    handleClose();
+    logout();
+  };
+
+  return (
+    <Container className={classes.root}>
+      <div>
+        <IconButton
+          className={classes.accBtn}
+          aria-controls="menu-appbar"
+          aria-haspopup="true"
+          onClick={handleMenu}
+          color="inherit"
+        >
+          <AccountCircle />
+        </IconButton>
+        <Menu
+          id="menu-appbar"
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          keepMounted
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          open={open}
+          onClose={handleClose}
+        >
+          <MenuItem onClick={handleClose}>Go to profile</MenuItem>
+          <MenuItem onClick={handleLogout}>Logout</MenuItem>
+        </Menu>
+      </div>
+    </Container>
+  );
+}

--- a/client/src/components/AccountButton/useStyles.ts
+++ b/client/src/components/AccountButton/useStyles.ts
@@ -1,0 +1,25 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+    },
+    title: {
+      flexGrow: 1,
+    },
+    accBtn: {
+      width: 50,
+      height: 50,
+      borderRadius: '50%',
+      filter: 'drop-shadow(0px 1px 1px rgba(74,106,149,0.2))',
+      background: '#FFF',
+      boxShadow: 'none',
+    },
+  }),
+);
+
+export default useStyles;

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,3 +1,4 @@
+import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -7,6 +8,7 @@ import { useSocket } from '../../context/useSocketContext';
 import { useHistory } from 'react-router-dom';
 import ChatSideBanner from '../../components/ChatSideBanner/ChatSideBanner';
 import { useEffect } from 'react';
+import NavBar from '../../components/NavBar/NavBar';
 
 export default function Dashboard(): JSX.Element {
   const classes = useStyles();
@@ -30,9 +32,7 @@ export default function Dashboard(): JSX.Element {
   return (
     <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}>
       <CssBaseline />
-      <Grid item className={classes.drawerWrapper}>
-        <ChatSideBanner loggedInUser={loggedInUser} />
-      </Grid>
+      <NavBar />
     </Grid>
   );
 }


### PR DESCRIPTION
### What this PR does (required):
- This PR has been made to create the dashboard skeleton. 

- There are two folders added to the Client/src/components => i. **AccountButton** ii. **NavBar**
- i. AccountButton => Creates the top right button where the user profile pic appears and has a drop-down menu which includes "**Go to profile**" and "**logout**". Currently, the logout button works and the user can go back to the main page. This is shown in the second image posted below.
- ii. NavBar => This folder contains the NavBar.tsx which creates the **blue navbar** and the **appbar** which is shown in the first image. The icons are imported from material UI so they don't match exactly with the same icons as shown in the mock-ups. However, if needed those can be customized separately. All buttons can be hovered over but do not have any functionalities yet. 
- Dashboard.tsx import NavBar.
- App.tsx has been modified to hold the current Dashboard theme. The user search has been removed.

### Screenshots / Videos (required):
- **Image 1**
![image](https://user-images.githubusercontent.com/77899847/127547027-b486290c-3236-4f03-b5e8-e6979174269a.png)

- **Image 2** 

![image](https://user-images.githubusercontent.com/77899847/127547113-7fb2b052-69e1-4148-bf76-6c165d4428a4.png)


### Any information needed to test this feature (required):
- Please run on Port: 3000
- Signup is required

### Any issues with the current functionality (optional):
