### PR TITLE
Created PortectedRoute component for the Dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,7 +7,7 @@ import Dashboard from './pages/Dashboard/Dashboard';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
-
+import ProtectedRoute from '../src/components/ProtectedRoute/ProtectedRoute';
 import './App.css';
 
 function App(): JSX.Element {
@@ -20,9 +20,7 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard">
-                  <Dashboard />
-                </Route>
+                <ProtectedRoute exact path="/dashboard" component={Dashboard} />
                 <Route path="*">
                   <Redirect to="/login" />
                 </Route>

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,11 @@
+import { useAuth } from '../../context/useAuthContext';
+import { RouteProps, Route, Redirect } from 'react-router-dom';
+import loading from '../../Images/loading.gif';
+
+export default function ProtectedRoute(component: RouteProps): JSX.Element {
+  const { loggedInUser } = useAuth();
+  const auth = loggedInUser;
+
+  if (!auth) return <img src={loading} />;
+  else return auth ? <Route {...component} /> : <Redirect to={{ pathname: '/login' }} />;
+}


### PR DESCRIPTION
### What this PR does (required):
- Only allows logged in user to get to the dashboard page otherwise it goes back to the login page

### Screenshots / Videos (required):
- First, the authenticator is checked to see if the user is logged in and shows a loading icon as below
- 
![image](https://user-images.githubusercontent.com/77899847/128454850-2c8c0ff1-5c60-437f-bb3c-58fbdddd52b3.png)

- Once the authentication is verified the page will look like below
- 
![image](https://user-images.githubusercontent.com/77899847/128455033-dbe68a8e-ba2a-4ffe-a880-1ced9ed483d0.png)


### Any information needed to test this feature (required):
- type /dashboard after http://localhost:3000 to see if you can see the page 

### Any issues with the current functionality (optional):
