### PR TITLE
Front-end detailed card dialog

### DIFF
--- a/client/src/components/DetailedCardDialog/AddColor/AddColor.tsx
+++ b/client/src/components/DetailedCardDialog/AddColor/AddColor.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Grow from '@material-ui/core/Grow';
+import Paper from '@material-ui/core/Paper';
+import Popper from '@material-ui/core/Popper';
+import MenuList from '@material-ui/core/MenuList';
+import useStyles from './useStyles';
+import { useState } from 'react';
+import { IconButton, Grid } from '@material-ui/core';
+import FormatColorFillOutlinedIcon from '@material-ui/icons/FormatColorFillOutlined';
+import { FiberManualRecord } from '@material-ui/icons';
+import { Task as TaskInterface } from '../../../interface/Task';
+
+export default function AddColor() {
+  const classes = useStyles();
+  const colors = ['#FFFFFF', '#FF5D48', '#EDAB1D', '#59B0FF', '#D460F7'];
+  const [open, setOpen] = React.useState(false);
+  const [state, setState] = useState({ expanded: false, color: colors, isDragging: true });
+  const anchorRef = React.useRef<HTMLButtonElement>(null);
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  const handleClose = (event: React.MouseEvent<EventTarget>) => {
+    if (anchorRef.current && anchorRef.current.contains(event.target as HTMLElement)) {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  function handleListKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      setOpen(false);
+    }
+  }
+
+  const changeColor = (color: string) => {
+    setState({ ...state, color: colors });
+  };
+
+  // return focus to the button when we transitioned from !open -> open
+  const prevOpen = React.useRef(open);
+  React.useEffect(() => {
+    if (prevOpen.current === true && open === false) {
+      anchorRef.current!.focus();
+    }
+
+    prevOpen.current = open;
+  }, [open]);
+
+  return (
+    <Grid className={classes.root}>
+      <Grid>
+        <IconButton
+          ref={anchorRef}
+          aria-controls={open ? 'menu-list-grow' : undefined}
+          aria-haspopup="true"
+          onClick={handleToggle}
+        >
+          <FormatColorFillOutlinedIcon />
+        </IconButton>
+        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
+          {({ TransitionProps, placement }) => (
+            <Grow
+              {...TransitionProps}
+              style={{ transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom' }}
+            >
+              <Paper>
+                <ClickAwayListener onClickAway={handleClose}>
+                  <MenuList autoFocusItem={open} id="menu-list-grow" onKeyDown={handleListKeyDown}>
+                    <Grid item xs={6} style={{ display: 'flex' }}>
+                      {colors.map((color, index) => (
+                        <FiberManualRecord
+                          style={{ stroke: '#E2E8F6', strokeWidth: color === colors[0] ? 1 : 0, fontSize: 30 }}
+                          htmlColor={color}
+                          key={index}
+                          onClick={() => {
+                            changeColor(color);
+                          }}
+                        ></FiberManualRecord>
+                      ))}
+                    </Grid>
+                  </MenuList>
+                </ClickAwayListener>
+              </Paper>
+            </Grow>
+          )}
+        </Popper>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/components/DetailedCardDialog/AddColor/AddColor.tsx
+++ b/client/src/components/DetailedCardDialog/AddColor/AddColor.tsx
@@ -13,7 +13,7 @@ import { Task as TaskInterface } from '../../../interface/Task';
 export default function AddColor() {
   const classes = useStyles();
   const colors = ['#FFFFFF', '#FF5D48', '#EDAB1D', '#59B0FF', '#D460F7'];
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const [state, setState] = useState({ expanded: false, color: colors, isDragging: true });
   const anchorRef = React.useRef<HTMLButtonElement>(null);
 

--- a/client/src/components/DetailedCardDialog/AddColor/AddColor.tsx
+++ b/client/src/components/DetailedCardDialog/AddColor/AddColor.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import Grow from '@material-ui/core/Grow';
 import Paper from '@material-ui/core/Paper';
 import Popper from '@material-ui/core/Popper';
 import MenuList from '@material-ui/core/MenuList';
 import useStyles from './useStyles';
-import { useState } from 'react';
 import { IconButton, Grid } from '@material-ui/core';
 import FormatColorFillOutlinedIcon from '@material-ui/icons/FormatColorFillOutlined';
 import { FiberManualRecord } from '@material-ui/icons';

--- a/client/src/components/DetailedCardDialog/AddColor/useStyles.ts
+++ b/client/src/components/DetailedCardDialog/AddColor/useStyles.ts
@@ -1,0 +1,14 @@
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    paper: {
+      marginRight: theme.spacing(2),
+    },
+  }),
+);
+
+export default useStyles;

--- a/client/src/components/DetailedCardDialog/Attachment/AttachmentItem.tsx
+++ b/client/src/components/DetailedCardDialog/Attachment/AttachmentItem.tsx
@@ -1,0 +1,28 @@
+import { Button, Box, Grid, IconButton } from '@material-ui/core';
+import useStyles from './useStyles';
+import AttachFileOutlinedIcon from '@material-ui/icons/AttachFileOutlined';
+import ClearIcon from '@material-ui/icons/Clear';
+
+export default function AttachmentItem() {
+  const classes = useStyles();
+
+  return (
+    <Grid>
+      <Grid container className={classes.titleContainer}>
+        <AttachFileOutlinedIcon className={classes.iconColor} />
+        <Grid className={classes.titleFont}>Attachment:</Grid>
+      </Grid>
+      <Box>
+        <input multiple type="file" className={classes.inputButton} />
+      </Box>
+      <Grid className={classes.savebuttonPosition}>
+        <Button className={classes.buttonStyle} color="primary" variant="contained" size="large">
+          Save
+        </Button>
+        <IconButton>
+          <ClearIcon color="primary" />
+        </IconButton>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/components/DetailedCardDialog/Attachment/useStyles.ts
+++ b/client/src/components/DetailedCardDialog/Attachment/useStyles.ts
@@ -1,0 +1,32 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  titleContainer: {
+    marginTop: '1%',
+    alignItems: 'center',
+  },
+  buttonStyle: {
+    width: '100px',
+    height: '40px',
+    padding: '5px 20px',
+    background: 'rgba(117,156,252,255)',
+    boxShadow: 'none',
+  },
+  iconColor: {
+    color: 'rgba(117,156,252,255)',
+  },
+  titleFont: {
+    fontSize: '1.5em',
+    fontWeight: 600,
+    padding: '10px 0px 10px 10px',
+    color: 'black',
+  },
+  inputButton: {
+    padding: '10px 0px 10px 35px',
+  },
+  savebuttonPosition: {
+    padding: '0px 0px 0px 35px',
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/DetailedCardDialog/Comments/CommentItem.tsx
+++ b/client/src/components/DetailedCardDialog/Comments/CommentItem.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { TextField, Grid, DialogTitle, Button, IconButton } from '@material-ui/core';
+import useStyles from './useStyles';
+import MessageOutlinedIcon from '@material-ui/icons/MessageOutlined';
+import ClearIcon from '@material-ui/icons/Clear';
+
+export default function CommentItem() {
+  const classes = useStyles();
+  const [content, setContent] = useState('');
+
+  return (
+    <Grid>
+      <Grid container className={classes.titleContainer}>
+        <MessageOutlinedIcon className={classes.iconColor} />
+        <Grid className={classes.titleFont}>Add comment:</Grid>
+      </Grid>
+      <TextField
+        fullWidth
+        multiline
+        rows={3}
+        placeholder={'Write a comment...'}
+        value={content}
+        variant="outlined"
+        className={classes.textField}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <Grid className={classes.savebuttonPosition}>
+        <Button className={classes.buttonStyle} color="primary" variant="contained" size="large">
+          Save
+        </Button>
+        <IconButton>
+          <ClearIcon color="primary" />
+        </IconButton>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/components/DetailedCardDialog/Comments/useStyles.ts
+++ b/client/src/components/DetailedCardDialog/Comments/useStyles.ts
@@ -1,0 +1,34 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  textField: {
+    display: 'flex',
+    width: '90%',
+    padding: '0px 0 10px 35px',
+  },
+  titleContainer: {
+    marginTop: '1%',
+    alignItems: 'center',
+  },
+  buttonStyle: {
+    width: '100px',
+    height: '40px',
+    padding: '5px 20px',
+    background: 'rgba(117,156,252,255)',
+    boxShadow: 'none',
+  },
+  iconColor: {
+    color: 'rgba(117,156,252,255)',
+  },
+  titleFont: {
+    fontSize: '1.5em',
+    fontWeight: 600,
+    padding: '10px 0px 10px 10px',
+    color: 'black',
+  },
+  savebuttonPosition: {
+    padding: '0px 0px 0px 35px',
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/DetailedCardDialog/Deadline/DatePickers.tsx
+++ b/client/src/components/DetailedCardDialog/Deadline/DatePickers.tsx
@@ -1,0 +1,34 @@
+import { TextField, Grid, DialogTitle, Button, IconButton } from '@material-ui/core';
+import useStyles from './useStyles';
+import ScheduleOutlinedIcon from '@material-ui/icons/ScheduleOutlined';
+import ClearIcon from '@material-ui/icons/Clear';
+
+export default function DatePickers() {
+  const classes = useStyles();
+
+  return (
+    <Grid>
+      <Grid container className={classes.titleContainer}>
+        <ScheduleOutlinedIcon className={classes.iconColor} />
+        <Grid className={classes.titleFont}>Deadline:</Grid>
+      </Grid>
+      <TextField
+        id="date"
+        type="date"
+        defaultValue="Pick a date"
+        className={classes.textField}
+        InputLabelProps={{
+          shrink: true,
+        }}
+      />
+      <Grid className={classes.savebuttonPosition}>
+        <Button className={classes.buttonStyle} color="primary" variant="contained" size="large">
+          Save
+        </Button>
+        <IconButton>
+          <ClearIcon color="primary" />
+        </IconButton>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/components/DetailedCardDialog/Deadline/useStyles.ts
+++ b/client/src/components/DetailedCardDialog/Deadline/useStyles.ts
@@ -1,0 +1,43 @@
+import React from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    container: {
+      display: 'flex',
+      flexWrap: 'wrap',
+    },
+    textField: {
+      marginLeft: theme.spacing(1),
+      marginRight: theme.spacing(1),
+      width: 200,
+      display: 'flex',
+      padding: '0px 0 15px 35px',
+    },
+    titleContainer: {
+      marginTop: '1%',
+      alignItems: 'center',
+    },
+    buttonStyle: {
+      width: '100px',
+      height: '40px',
+      padding: '5px 20px',
+      background: 'rgba(117,156,252,255)',
+      boxShadow: 'none',
+    },
+    iconColor: {
+      color: 'rgba(117,156,252,255)',
+    },
+    titleFont: {
+      fontSize: '1.5em',
+      fontWeight: 600,
+      padding: '10px 0px 10px 10px',
+      color: 'black',
+    },
+    savebuttonPosition: {
+      padding: '0px 0px 0px 35px',
+    },
+  }),
+);
+
+export default useStyles;

--- a/client/src/components/DetailedCardDialog/Description/DescriptionItem.tsx
+++ b/client/src/components/DetailedCardDialog/Description/DescriptionItem.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { TextField, Grid, Button, IconButton } from '@material-ui/core';
+import useStyles from './useStyles';
+import ImportContactsOutlinedIcon from '@material-ui/icons/ImportContactsOutlined';
+import ClearIcon from '@material-ui/icons/Clear';
+
+export default function DescriptionItem() {
+  const classes = useStyles();
+  const [content, setContent] = useState('');
+
+  return (
+    <Grid>
+      <Grid container className={classes.titleContainer}>
+        <ImportContactsOutlinedIcon className={classes.iconColor} />
+        <Grid className={classes.titleFont}>Description:</Grid>
+      </Grid>
+      <TextField
+        variant="outlined"
+        placeholder={'Add a description...'}
+        className={classes.textField}
+        rows={6}
+        fullWidth
+        multiline
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <Grid className={classes.savebuttonPosition}>
+        <Button className={classes.buttonStyle} color="primary" variant="contained" size="large">
+          Save
+        </Button>
+        <IconButton>
+          <ClearIcon color="primary" />
+        </IconButton>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/components/DetailedCardDialog/Description/useStyles.ts
+++ b/client/src/components/DetailedCardDialog/Description/useStyles.ts
@@ -1,0 +1,34 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  textField: {
+    display: 'flex',
+    width: '90%',
+    padding: '0px 0 10px 35px',
+  },
+  titleContainer: {
+    marginTop: '0%',
+    alignItems: 'center',
+  },
+  buttonStyle: {
+    width: '100px',
+    height: '40px',
+    padding: '5px 20px',
+    background: 'rgba(117,156,252,255)',
+    boxShadow: 'none',
+  },
+  iconColor: {
+    color: 'rgba(117,156,252,255)',
+  },
+  titleFont: {
+    fontSize: '1.5em',
+    fontWeight: 600,
+    padding: '10px 0px 10px 10px',
+    color: 'black',
+  },
+  savebuttonPosition: {
+    padding: '0px 0px 0px 35px',
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/DetailedCardDialog/DetailedCardDialog.tsx
+++ b/client/src/components/DetailedCardDialog/DetailedCardDialog.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Button, Typography, Grid, Box, Dialog, Divider, DialogContent } from '@material-ui/core';
+import { useState, MouseEvent } from 'react';
+import useStyles from './useStyles';
+import AssignmentOutlinedIcon from '@material-ui/icons/AssignmentOutlined';
+import DescriptionItem from './Description/DescriptionItem';
+import CommentItem from './Comments/CommentItem';
+import DatePickers from './Deadline/DatePickers';
+import DialogButtons from './DialogButtons/DialogButtons';
+import AddColor from './AddColor/AddColor';
+import AttachmentItem from './Attachment/AttachmentItem';
+import { classicNameResolver } from 'typescript';
+
+const emails = [''];
+export interface IDialogItem {
+  content: string;
+  icon: string;
+  title?: string;
+}
+
+export interface DetailedCardDialogProps {
+  open: boolean;
+  selectedValue: string;
+  onClose: (value: string) => void;
+}
+
+function DetailedCardDialog(props: DetailedCardDialogProps) {
+  const classes = useStyles();
+  const { onClose, selectedValue, open } = props;
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const handleClose = () => {
+    onClose(selectedValue);
+  };
+
+  const handleListItemClick = (value: string) => {
+    onClose(value);
+  };
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  return (
+    <Dialog
+      onClose={handleClose}
+      aria-labelledby="simple-dialog-title"
+      open={open}
+      classes={{ paper: classes.dialogBox }}
+    >
+      <Grid container spacing={2} className={classes.dialogBorder}>
+        <Grid item xs={12}>
+          <Grid container className={classes.titleContainer}>
+            <AssignmentOutlinedIcon className={classes.iconColor} />
+            <Grid className={classes.mainTitle}>Card Title</Grid>
+            <AddColor />
+          </Grid>
+          <Grid className={classes.progressBar}>In list ...</Grid>
+        </Grid>
+      </Grid>
+      <Divider className={classes.divider} />
+      <DialogContent>
+        <Grid container className={classes.dialogBorder}>
+          <Grid item xs={10}>
+            <DescriptionItem />
+            <CommentItem />
+            <DatePickers />
+            <AttachmentItem />
+          </Grid>
+          <Grid item xs={2}>
+            <Grid container direction="column" className={classes.buttonItem}>
+              <Grid item>
+                <Box className={classes.allButtons}>
+                  <Typography variant="caption" className={classes.buttonTitles}>
+                    ADD TO CARD:
+                  </Typography>
+                  <DialogButtons title="Description" />
+                  <DialogButtons title="Comment" />
+                  <DialogButtons title="Deadline" />
+                  <DialogButtons title="Attachment" />
+                </Box>
+              </Grid>
+              <Grid item>
+                <Box className={classes.allButtons}>
+                  <Typography variant="caption" className={classes.buttonTitles}>
+                    ACTIONS:
+                  </Typography>
+                  <DialogButtons title="Move" />
+                  <DialogButtons title="Copy" />
+                  <DialogButtons title="Delete" />
+                  <DialogButtons title="Share" />
+                </Box>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function SimpleDialogDemo() {
+  const [open, setOpen] = React.useState(false);
+  const [selectedValue, setSelectedValue] = React.useState(emails[1]);
+  const classes = useStyles();
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (value: string) => {
+    setOpen(false);
+    setSelectedValue(value);
+  };
+
+  return (
+    <div>
+      <Button className={classes.demoButton} onClick={handleClickOpen}>
+        Detailed Card Dialog
+      </Button>
+      <DetailedCardDialog selectedValue={selectedValue} open={open} onClose={handleClose} />
+    </div>
+  );
+}

--- a/client/src/components/DetailedCardDialog/DialogButtons/DialogButtons.tsx
+++ b/client/src/components/DetailedCardDialog/DialogButtons/DialogButtons.tsx
@@ -1,0 +1,11 @@
+import { Button } from '@material-ui/core';
+import useStyles from './useStyles';
+
+type Props = {
+  title: string;
+};
+export default function DialogButtons({ title }: Props) {
+  const classes = useStyles();
+
+  return <Button className={classes.buttonstyle}>{title}</Button>;
+}

--- a/client/src/components/DetailedCardDialog/DialogButtons/useStyles.ts
+++ b/client/src/components/DetailedCardDialog/DialogButtons/useStyles.ts
@@ -1,0 +1,17 @@
+import { makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  buttonstyle: {
+    backgroundColor: '#e8eaf6',
+    color: '#757575',
+    padding: '8px 0',
+    margin: '5px 5px',
+    width: '110px',
+    '&:hover': {
+      background: 'rgba(117,156,252,255)',
+      color: 'white',
+    },
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/DetailedCardDialog/useStyles.ts
+++ b/client/src/components/DetailedCardDialog/useStyles.ts
@@ -1,0 +1,69 @@
+import { makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  dialogBox: {
+    minWidth: '55%',
+    height: '760px',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    overflow: 'hidden',
+    display: 'flex',
+  },
+  dialogBorder: {
+    padding: '0 3%',
+  },
+  titleContainer: {
+    marginTop: '2%',
+    alignItems: 'center',
+    padding: '0px 0px 0px 25px',
+  },
+  divider: {
+    width: '100%',
+  },
+  buttonItem: {
+    display: 'flex',
+    justify: 'flex-start',
+    padding: '0px 0px 0 25px',
+    alignItems: 'center',
+  },
+  allButtons: {
+    paddingTop: '20px',
+    flexDirection: 'column',
+    alignItems: 'left',
+    display: 'flex',
+  },
+  buttonTitles: {
+    color: '#9fa8da',
+    fontSize: '0.9em',
+    fontWeight: 600,
+    padding: '0 5px 5px',
+  },
+  iconColor: {
+    color: 'rgba(117,156,252,255)',
+  },
+  mainTitle: {
+    padding: '10px 0px 10px 10px',
+    color: 'black',
+    fontWeight: 600,
+    fontSize: '2em',
+  },
+  progressBar: {
+    padding: '0px 0px 10px 60px',
+    fontSize: '1.2em',
+    fontWeight: 400,
+    color: '#9fa8da',
+  },
+  demoButton: {
+    backgroundColor: '#e8eaf6',
+    color: '#757575',
+    padding: '8px 0',
+    margin: '5px 5px',
+    width: '110px',
+    '&:hover': {
+      background: 'rgba(117,156,252,255)',
+      color: 'white',
+    },
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
### What this PR does (required):
- This PR is the front-end of the detailed card
- When a card is clicked on in the board section, this dialog pops up and allows the user to add [Description, Comment, Attachment, Deadline, etc..]
- There are also **Action** buttons that allow the user to [Move, Delete, Copy, Share] the cards
- At the top of the card, the color should match the card's color and can be changed. 
- **In list...** should be integrated with board column's title
- Every section's code is written in separate folders and then integrated into one main file called **DetailedCardDialog.tsx**
- The video below shows the current functionality

### Screenshots / Videos (required):

- A demo shot of the front-end functionality of the detailed card.

https://user-images.githubusercontent.com/77899847/128801259-7c294c4f-d2b9-423a-94ad-c3e124cab3ec.mp4


### Any information needed to test this feature (required):
- Should be run on **port 3000**

### Any issues with the current functionality (optional):
- The save buttons, color chooser at the top, and column title will need to be integrated with back-end and the board
- The Section and Action buttons will also need to be integrated with the back-end
